### PR TITLE
Use node-16 instead of node-12

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -19,5 +19,5 @@ inputs:
     default: false
 
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'


### PR DESCRIPTION
- the upstream repo is no longer maintained
- pull this fix from another fork: https://github.com/gaoDean/cargo